### PR TITLE
Small performance improvement

### DIFF
--- a/src/core/Tc.Application.js
+++ b/src/core/Tc.Application.js
@@ -89,7 +89,7 @@
 
             $ctx = $ctx || this.$ctx;
 
-            $('.mod', $ctx).each(function() {
+            $ctx.find('.mod').each(function() {
                 var $this = $(this);
 
                 /**


### PR DESCRIPTION
According to Addy Osmani, using a context in the selector is a little slower than using "find" directly (see http://www.slideshare.net/AddyOsmani/jquery-proven-performance-tips-tricks/33).
