### PR TITLE
Using this instead of $(this)

### DIFF
--- a/src/core/Tc.Application.js
+++ b/src/core/Tc.Application.js
@@ -89,9 +89,7 @@
 
             $ctx = $ctx || this.$ctx;
 
-            $ctx.find('.mod').each(function() {
-                var $this = $(this);
-
+            $ctx.find('.mod').each(function() {                
                 /**
                  * Indicates that it is a base module, this is the default and
                  * no JavaScript needs to be involved. It must occur excactly
@@ -133,8 +131,8 @@
 
                 if (classes.length > 1) {
                     var modName,
-                            skins = [],
-                            connectors = [];
+                            dataConnectors = this.getAttribute('data-connectors'),                            
+                            skins = [];
 
                     for (var i = 0, len = classes.length; i < len; i++) {
                         var part = $.trim(classes[i]);
@@ -149,8 +147,8 @@
                     }
 
 
-                    if ($this.attr('data-connectors')) {
-                        connectors = $this.attr('data-connectors').split(',');
+                    if (dataConnectors) {
+                        var connectors = dataConnectors.split(',');
                         for (var i = 0, len = connectors.length; i < len; i++) {
                             connectors[i] = $.trim(connectors[i]);
                         }
@@ -158,7 +156,7 @@
 
 
                     if (modName && Tc.Module[modName]) {
-                        modules.push(that.registerModule($this, modName, skins, connectors));
+                        modules.push(that.registerModule($(this), modName, skins, connectors));
                     }
                 }
             });

--- a/src/core/Tc.Application.js
+++ b/src/core/Tc.Application.js
@@ -129,7 +129,7 @@
                  * @config data-connectors
                  */
 
-                var classes = $this.attr('class').split(' ');
+                var classes = this.className.split(' ');
 
                 if (classes.length > 1) {
                     var modName,


### PR DESCRIPTION
Inside the callback function of jQuery's each this points to the current DOM element, so you can use "this" instead of "$(this)" in some cases. Should always be (a little) faster :)
