### PR TITLE
Tc.Connector.notify iterates over built-in properties in IE<9 [fatal error]

### DIFF
--- a/src/core/Tc.Connector.js
+++ b/src/core/Tc.Connector.js
@@ -60,23 +60,27 @@
          * Notifies all registered components about the state change (to be overriden in the specific connectors).
          *
          * @method notify
-         * @param {Module} component the module that sends the state change
+         * @param {Module} origin the module that sends the state change
          * @param {String} state the state
          * @param {Object} data contains the state relevant data (if any)
          * @param {Function} callback the callback function (could be executed after an asynchronous action)
          * @return {boolean} indicates whether the default action should be excuted or not
          */
-        notify: function(component, state, data, callback) {
-            /* 
+        notify: function(origin, state, data, callback) {
+            /*
              * gives the components the ability to prevent the default- and afteraction from the events
              * (by returning false in the on<Event>-Handler)
              */
             var proceed = true,
-                components = this.components;
+                components = this.components,
+                component,
+                i;
 
-            for (var id in components) {
-                if (components[id].component !== component && components[id].component[state]) {
-                    if (components[id].component[state](data, callback) === false) {
+            for (i = 0; i < components.length; i++) {
+                component = components[i].component;
+
+                if (component !== origin && component[state]) {
+                    if (component[state](data, callback) === false) {
                         proceed = false;
                     }
                 }


### PR DESCRIPTION
A for-in loop is used to iterate over an array storing all components (modules) registered with the connector. On IE versions up to 8 this also loops over built-in properties of the array and the method fails with a fatal error.

I'm fixing this using a 'for' loop.

In addition I'm storing components[i].component in a local var for faster lookup and better minification.
