### PR TITLE
New module property: modName

### DIFF
--- a/src/core/Tc.Application.js
+++ b/src/core/Tc.Application.js
@@ -286,7 +286,7 @@
                 $node.data('id', id);
 
                 // Instantiate module
-                modules[id] = new Tc.Module[modName]($node, this.sandbox, id);
+                modules[id] = new Tc.Module[modName]($node, this.sandbox, id, modName);
 
                 // Decorate it
                 for (var i = 0, len = skins.length; i < len; i++) {

--- a/src/core/Tc.Module.js
+++ b/src/core/Tc.Module.js
@@ -22,7 +22,7 @@
          * @param {String} id 
          *      The Unique module ID
          */
-        init: function($ctx, sandbox, id) {
+        init: function($ctx, sandbox, id, modName) {
             /**
              * Contains the module context.
              *
@@ -54,6 +54,14 @@
              * @type Sandbox
              */
             this.sandbox = sandbox;
+
+            /**
+             * The module name (this module's property name in the Tc.Module super class)
+             *
+             * @property modName
+             * @type String
+             */
+            this.modName = modName;
         },
 
         /**

--- a/test/core/templates.html
+++ b/test/core/templates.html
@@ -54,16 +54,16 @@
     (function($) {
         // Modules
         Tc.Module.None = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             }
         });
 
         Tc.Module.All = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             },
             on: function(callback) {
                 messages.push('Module All: on');
@@ -78,9 +78,9 @@
         });
 
         Tc.Module.Dependency = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             },
             on: function(callback) {
                 yepnope({
@@ -99,9 +99,9 @@
         });
 
         Tc.Module.Register = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             },
             on: function(callback) {
                 messages.push('Module Register: on');
@@ -212,9 +212,9 @@
         };
 
         Tc.Module.Subscription = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             },
 
             on: function(callback) {
@@ -240,9 +240,9 @@
         });
 
         Tc.Module.SpecialSubscription = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             },
 
             on: function(callback) {
@@ -299,9 +299,9 @@
         });
 
         Tc.Module.UnSubscription = Tc.Module.extend({
-            init: function($ctx, sandbox, id) {
+            init: function($ctx, sandbox, id, modName) {
                 // call base constructor
-                this._super($ctx, sandbox, id);
+                this._super($ctx, sandbox, id, modName);
             },
 
             on: function(callback) {

--- a/test/core/tests/application.js
+++ b/test/core/tests/application.js
@@ -49,6 +49,7 @@
 
             // check the module properties
             ok(module instanceof Tc.Module, 'instance of Tc.Module');
+            ok(module instanceof Tc.Module[module.modName], 'instance of Tc.Module[module.modName]');
             ok(module.hasOwnProperty('$ctx'), 'no skins applied');
             equals(0, Object.keys(module.connectors).length, 'no connectors');
             deepEqual(module.$ctx, $node, 'context node');


### PR DESCRIPTION
New module property: modName (this module's property name in the Tc.Module super class).

So that when inspecting (a bunch of) modules you actually know which one you're looking at.

This also makes it possible to create a new module instance programmatically when you only have the module itself. Something like this...

`var testModInstance = testApp.registerModule($node, module.modName)`
or even this...
`var module = new Tc.Module[module.modName]([appropriate args])`

A useful test assertion is included in the commit:
`ok(module instanceof Tc.Module[module.modName], 'instance of Tc.Module[module.modName]');`
