### PR TITLE
Should namespace module id for markup

### DIFF
--- a/src/core/Tc.Application.js
+++ b/src/core/Tc.Application.js
@@ -282,7 +282,7 @@ Tc.Application = Class.extend({
         if (modName && Tc.Module[modName]) {
             // Generate a unique ID for every module
             var id = modules.length;
-            $node.data('id', id);
+            $node.data('terrific-id', id);
 
             // Instantiate module
             modules[id] = new Tc.Module[modName]($node, this.sandbox, id);

--- a/src/core/Tc.Sandbox.js
+++ b/src/core/Tc.Sandbox.js
@@ -89,7 +89,7 @@ Tc.Sandbox = Class.extend({
 
             $ctx.find('.mod').add($ctx).each(function () {
                 // check for instance
-                var id = $(this).data('id');
+                var id = $(this).data('terrific-id');
 
                 if (id !== undefined) {
                     module = self.getModuleById(id);


### PR DESCRIPTION
Please don't use `id` as a key when storing module ids on a markup module with `$.data()`.
`terrific-id` would be preferable and prevent collision with other apps. `id` is just to common to be a safe choice.
