### PR TITLE
Array as data on .fire()

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -2,7 +2,7 @@
 <project default="all" basedir=".">
 
     <!-- release variables -->
-    <property name="VERSION" value="2.0.2" description="Version"/>
+    <property name="VERSION" value="2.0.3" description="Version"/>
     <property name="YUIDOC_CONFIG" value="yuidoc/yuidoc.json" description="YUIDoc config parameters (incl. version)"/>
 
     <!-- paths -->

--- a/build/yuidoc/yuidoc.json
+++ b/build/yuidoc/yuidoc.json
@@ -1,7 +1,7 @@
 {
     "name": "Terrific JavaScript Framework",
     "description": "TerrificJS allows you to modularize your jQuery code by solely relying on naming conventions.",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "url": "http://terrifically.org/api/",
     "options" : {
         "outdir" : "../release/docs"

--- a/src/core/Tc.Module.js
+++ b/src/core/Tc.Module.js
@@ -139,7 +139,7 @@ Tc.Module = Class.extend({
                 channels = undefined;
             }
 
-            if ($.isArray(data)) {
+            if ($.isArray(data) && !$.isArray(channels)) {
                 // (state, channels, defaultAction)
                 channels = data;
                 data = undefined;


### PR DESCRIPTION
I've come across this bug (or feature, not sure) while consuming data from a JSON service and I'll try to explain it as simple as possible.
# Problem
## Example JSON

``` json
[
  {
    "name": "Jon Snow",
    "location": "Castle Black",
    "pet": "Direwolf"
  },
  {
    "name": "Daenerys Targaryen",
    "location": "Meereen",
    "pet": "Dragons"
  }
]
```

Now I have a module (let's call it `DataFetch`) which is responsible for handling the AJAX call. What it does is distributing the response to other modules.

``` javascript
mod.fire('dataLoaded', response, ['starks']);
```

Currently this will result in a JS error.

``` javascript
the module #1337 is not connected to connector [object Object]
```

This is because TerrificJS will use the `data` argument as `channels` if `data` is an array.
# Possible Solution
## Dirty Quickfix

Just add a empty defaultAction as argument 4:

``` javascript
mod.fire('dataLoaded', response, ['starks'], function(){});
```
##  Pull Request

With this PR, the code will only take the `data` argument as `channels` if `channels` (third argument) is **not an array**. Otherwise it will leave everything as is. This change will be able to handle the following cases:

``` javascript
mod.fire('state', response, ['starks', 'targaryen']);
// and
mod.fire('state', ['starks', 'targaryen']);
```

These are handled on L#134 - 147 (2-3 params). 

There's also the possibility of max. 2 params (L#121 - 133) but I'm unsure about how to handle that case. The code checks whether `data` is an array, and takes it as `channels`. Both arguments are optional though, so it's pretty hard to recognize what it actually is.
