### PR TITLE
Change module._ctx from type from `Node` to `Element` for TypeScript

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function (config) {
 		// list of files / patterns to load in the browser
 		files: [
 			'bower_components/es5-shim/es5-shim.min.js',
-			'bower_components/es6-promise/promise.min.js',
+			'bower_components/es6-promise/es6-promise.min.js',
 			'spec/helpers/*.js',
 			'dist/terrific.js',
 			'spec/components/*.js',

--- a/src/terrific.d.ts
+++ b/src/terrific.d.ts
@@ -1,21 +1,21 @@
 /// <reference path="es6-promise.d.ts" />
 declare module T {
     class Application {
-        _ctx: Node;
+        _ctx: Element;
         _sandbox: Sandbox;
 		_config: any;
         _modules: any;
         _id: number;
 
-        constructor(ctx?: Node, config?: any);
+        constructor(ctx?: Element, config?: any);
 
-        registerModules(ctx?: Node): Module[];
+        registerModules(ctx?: Element): Module[];
         unregisterModules(modules?: any): void;
         start(modules?: any): Promise<void>;
         stop(modules?: any): void;
-        registerModule(ctx: Node, mod: string, namespace?: any): Module;
-        registerModule(ctx: Node, mod: string, decorators?: string|string[]): Module;
-        registerModule(ctx: Node, mod: string, decorators?: string|string[], namespace?: any): Module;
+        registerModule(ctx: Element, mod: string, namespace?: any): Module;
+        registerModule(ctx: Element, mod: string, decorators?: string|string[]): Module;
+        registerModule(ctx: Element, mod: string, decorators?: string|string[], namespace?: any): Module;
         getModuleById(id: number): Module;
     }
 
@@ -50,8 +50,8 @@ declare module T {
 
         constructor(application: Application);
 
-        addModules(ctx: Node): Module[];
-        removeModules(modules: Node|Module[]): Sandbox;
+        addModules(ctx: Element): Module[];
+        removeModules(modules: Element|Module[]): Sandbox;
         getModuleById(id: number): Module;
         getConfig(): any;
         getConfigParam(name: string): any;
@@ -61,11 +61,11 @@ declare module T {
     }
 
     class Module {
-        _ctx: Node;
+        _ctx: Element;
         _sandbox: Sandbox;
         _events: EventEmitter;
 
-        constructor(ctx: Node, sandbox: Sandbox);
+        constructor(ctx: Element, sandbox: Sandbox);
 
         start(resolve: (value?: any) => void, reject: (error?: any) => void): void;
         stop(): void;


### PR DESCRIPTION
I encountered a problem when using terrificjs with TypeScript: When trying to access `this._ctx.querySelector` the TypeScript compiler would complain that the method `querySelector` is not implemented on type `Node`. Changing this to `Element` fixes it. 

While something like this is possible: 

```typescript
let ctx = <Element>this._ctx;
let myElement = ctx.querySelector('.myElement');
```

it is also tedious to do this every time.

I do not think this is a breaking change, since the context of a module should always be a DOMElement. Node is after all just an interface that HTML elements implement.

That being said, I'm aware that there might be some ramifications to this. If there are some further changes to be made I'll be happy to update my PR :)